### PR TITLE
Meido\HTML\HTML should be constructed with an instance of Illuminate\Routing\UrlGenerator.

### DIFF
--- a/src/TwigBridge/Extensions/Html.php
+++ b/src/TwigBridge/Extensions/Html.php
@@ -31,7 +31,7 @@ class Html extends Extension
 
     public function setApp(Application $app)
     {
-        $app['html'] = new Meido_HTML($app);
+        $app['html'] = new Meido_HTML($app['url']);
         $app['form'] = new Meido_Form($app);
 
         parent::setApp($app);


### PR DESCRIPTION
Fixed a bug while using actual master.
