### PR TITLE
Fixed a typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Add `rcrowe\twigbridge` as a requirement to composer.json:
 ```javascript
 {
     "require": {
-        "rcrowe\twigbridge": "dev-master"
+        "rcrowe/twigbridge": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
Composer interprets `\t` as a <TAB> :)
