### PR TITLE
Use 'minimum-stability: dev' in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "minimum-stability": "dev",
     "name": "rcrowe/twigbridge",
     "description": "Adds the power of Twig to Illuminate / Laravel 4",
     "keywords": ["laravel", "twig"],
@@ -11,10 +12,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "twig/twig": "1.12.*",
+        "twig/twig": "1.12.*@stable",
         "illuminate/foundation": "4.0.*",
-        "meido/html": ">=1.0.7",
-        "meido/form": ">=1.0.4"
+        "meido/html": ">=1.0.7@stable",
+        "meido/form": ">=1.0.4@stable"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2"


### PR DESCRIPTION
This fixes the failing Travis tests by declaring "minimum-stability: dev" in the `composer.json` so that it can find the `illuminate/foundation` package.

I've also marked the other packages as `@stable` so it won't install dev releases of it.
