### PR TITLE
Use composer --prefer-source when running Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
     - curl -s https://getcomposer.org/installer | php
-    - php ./composer.phar install --dev
+    - php ./composer.phar install --dev --prefer-source
 
 script: phpunit --configuration phpunit.xml.dist
 


### PR DESCRIPTION
This just add the `prefer-source` flag to the `composer install` which will get around Github API rate limit errors when running tests in Travis.
