### PR TITLE
Twig debug Extension loading

### DIFF
--- a/src/TwigBridge/TwigBridge.php
+++ b/src/TwigBridge/TwigBridge.php
@@ -190,7 +190,6 @@ class TwigBridge
 
         // Load extensions
         foreach ($this->getExtensions() as $twig_extension) {
-
             // Get an instance of the extension
             // Support for string, closure and an object
             if (is_string($twig_extension)) {
@@ -203,6 +202,10 @@ class TwigBridge
 
             // Add extension to twig
             $twig->addExtension($twig_extension);
+        }
+
+        if ( array_key_exists('debug', $this->options) && ($this->options['debug'] === true) ) {
+            $twig->addExtension(new \Twig_Extension_Debug());
         }
 
         $this->app['events']->fire('twigbridge.twig', array('twig' => $twig));


### PR DESCRIPTION
Hello!

When I want to use the debug functionality of twig the debug extension has to be loaded explicitly. Like mentioned in the twig docs: http://twig.sensiolabs.org/doc/functions/dump.html

This was missing in the twigbridge.

Greetings
Carsten
