### PR TITLE
Swap illuminate/foundation for illuminate/framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "twig/twig": "1.12.*@stable",
-        "illuminate/foundation": "4.0.*"
+        "laravel/framework": "4.0.*"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",


### PR DESCRIPTION
illuminate/foundation was deprecated so when using this as a dependency for other packages when developing in the workbench, the autoloader uses the foundation's classes which are out of date.
