### PR TITLE
Dont re-create EngineResolver during Engine registration

### DIFF
--- a/src/TwigBridge/TwigServiceProvider.php
+++ b/src/TwigBridge/TwigServiceProvider.php
@@ -30,7 +30,6 @@ class TwigServiceProvider extends ViewServiceProvider
         $this->app['config']->package('rcrowe/twigbridge', __DIR__.'/../config');
 
         $this->registerTwigEngine();
-        $this->registerEnvironment();
         $this->registerCommands();
     }
 
@@ -45,7 +44,7 @@ class TwigServiceProvider extends ViewServiceProvider
     {
         $app = $this->app;
 
-        $app['view']->addExtension('twig', 'twig', function () use ($app)
+        $app['view']->addExtension($app['config']->get('twigbridge::extension', 'twig'), 'twig', function () use ($app)
         {
             // Grab Twig
             $bridge = new TwigBridge($app);
@@ -56,17 +55,6 @@ class TwigServiceProvider extends ViewServiceProvider
 
             return new Engines\TwigEngine($twig, $globals);
         });
-    }
-
-    /**
-     * Register the view environment.
-     *
-     * @param  Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    public function registerEnvironment()
-    {
-        $this->app['view']->addExtension($this->app['config']->get('twigbridge::extension', 'twig'), 'twig');
     }
 
     /**


### PR DESCRIPTION
This fixes the problem when you are trying to use multiple EngineBridges.

Also, it makes stuff much cleaner as you are now re-using the already created `EngineResolver`.

There was also another [PullRequest](https://github.com/iwyg/xsltbridge/pull/3) sent to [XsltBridge](https://github.com/iwyg/xsltbridge) as those two bridges were the ones I notices clashing.
