### PR TITLE
Autoescape incorrect default value

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -67,7 +67,7 @@ return array(
 
         // If set to true, auto-escaping will be enabled by default for all templates.
         // default: true
-        'autoescape' => false,
+        'autoescape' => true,
 
         // A flag that indicates which optimizations to apply
         // (default to -1 -- all optimizations are enabled; set it to 0 to disable)


### PR DESCRIPTION
Comment says default = true, but value is set to false. (Or the comment is wrong)
