### PR TITLE
Pass global view variables to Twig

### DIFF
--- a/src/TwigBridge/View/View.php
+++ b/src/TwigBridge/View/View.php
@@ -29,11 +29,14 @@ class View extends \Illuminate\View\View
         //TODO: There must be a better way to do this?
         
         // Pass globals to Twig's global scope
-        $twig = $this->engine->getTwig();
-        foreach ($this->environment->getShared() as $key => $value)
-        {
-            $twig->addGlobal($key, $value);
-        }
+        if ($this->engine instanceof \TwigBridge\Engines\TwigEngine)
+		{
+			$twig = $this->engine->getTwig();
+			foreach ($this->environment->getShared() as $key => $value)
+			{
+				$twig->addGlobal($key, $value);
+			}
+		}
         
         return $this->engine->get($this->path, $this->gatherData(), $this->view);
     }


### PR DESCRIPTION
Laravel sets some variables in the View that are meant to be globally accessible. The main one is "errors" used with form validation. These need to be passed into Twig's global variable handler so it can be accessed within macros and subtemplates.
