### PR TITLE
[0.6] Implement CompilerInterface

### DIFF
--- a/src/Compiler/Twig.php
+++ b/src/Compiler/Twig.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the TwigBridge package.
+ *
+ * @copyright Robert Crowe <hello@vivalacrowe.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace TwigBridge\Compiler;
+
+use Twig_Environment;
+use Twig_Error;
+use Illuminate\View\Compilers\CompilerInterface;
+
+/**
+ * Twig compiler for Laravel.
+ */
+class Twig implements CompilerInterface
+{
+    /**
+     * @var \Twig_Environment
+     */
+    protected $twig;
+
+    /**
+     * Create a new instance of the Twig engine.
+     *
+     * @param \Twig_Environment $twig
+     */
+    public function __construct(Twig_Environment $twig)
+    {
+        $this->twig = $twig;
+    }
+
+    /**
+     * Returns the instance of Twig used to render the template.
+     *
+     * @return \Twig_Environment
+     */
+    public function getTwig()
+    {
+        return $this->twig;
+    }
+
+    /**
+     * Get the path to the compiled version of a view.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function getCompiledPath($path)
+    {
+        return $this->twig->getCacheFilename($path);
+    }
+
+    /**
+     * Determine if the given view is expired.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    public function isExpired($path)
+    {
+        $time = filemtime($this->getCompiledPath($path));
+        return $this->twig->isTemplateFresh($path, $time);
+    }
+
+    /**
+     * Compile the view at the given path.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function compile($path)
+    {
+        try{
+            $this->twig->loadTemplate($path);
+        }catch(\Exception $e){
+            // Something went wrong..
+        }
+    }
+}

--- a/src/Engine/Twig.php
+++ b/src/Engine/Twig.php
@@ -16,16 +16,18 @@ use Twig_Environment;
 use Twig_Error_Loader;
 use InvalidArgumentException;
 use TwigBridge\Twig\Template;
+use Illuminate\View\Engines\CompilerEngine;
+use TwigBridge\Compiler\Twig as TwigCompiler;
 
 /**
  * Twig engine for Laravel.
  */
-class Twig implements EngineInterface
+class Twig extends CompilerEngine
 {
     /**
-     * @var \Twig_Environment
+     * @var TwigCompiler
      */
-    protected $twig;
+    protected $compiler;
 
     /**
      * @var array Global data that is always passed to the template.
@@ -35,23 +37,13 @@ class Twig implements EngineInterface
     /**
      * Create a new instance of the Twig engine.
      *
-     * @param \Twig_Environment $twig
+     * @param TwigCompiler      $compiler
      * @param array             $globalData
      */
-    public function __construct(Twig_Environment $twig, array $globalData = [])
+    public function __construct(TwigCompiler $compiler, array $globalData = [])
     {
-        $this->twig       = $twig;
+        $this->compiler   = $compiler;
         $this->globalData = $globalData;
-    }
-
-    /**
-     * Returns the instance of Twig used to render the template.
-     *
-     * @return \Twig_Environment
-     */
-    public function getTwig()
-    {
-        return $this->twig;
     }
 
     /**
@@ -88,7 +80,7 @@ class Twig implements EngineInterface
     public function load($name)
     {
         try {
-            $template = $this->twig->loadTemplate($name);
+            $template = $this->compiler->getTwig()->loadTemplate($name);
         } catch (Twig_Error_Loader $e) {
             throw new InvalidArgumentException("Error in $name: ". $e->getMessage(), $e->getCode(), $e);
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -205,9 +205,15 @@ class ServiceProvider extends ViewServiceProvider
             });
         }
 
+        $this->app->bindIf('twig.compiler', function () {
+            return new Compiler\Twig(
+                $this->app['twig']
+            );
+        });
+
         $this->app->bindIf('twig.engine', function () {
             return new Engine\Twig(
-                $this->app['twig'],
+                $this->app['twig.compiler'],
                 $this->app['config']->get('twigbridge::twig.globals', [])
             );
         });
@@ -223,6 +229,7 @@ class ServiceProvider extends ViewServiceProvider
         return array(
             'twig',
             'twig.bridge',
+            'twig.compiler',
             'twig.engine',
             'twig.extensions',
             'twig.options',


### PR DESCRIPTION
See #72, adds a Compiler for Laravel. Not sure if `isExpired` and
`getCompiledPath` work as intended by the interface, but I don't think
they are ever called.
Also might think about where to put the Environment, I removed it now
from the engine, but maybe let the compiler also load the templates? Or
inject TwigEnvironment directly in the engine?
