### PR TITLE
The callback option was not being honoured for Facades

### DIFF
--- a/src/Extension/Loader/Facades.php
+++ b/src/Extension/Loader/Facades.php
@@ -47,7 +47,7 @@ class Facades extends Loader
         foreach ($load as $facade => $options) {
             list($facade, $callable, $options) = $this->parseCallable($facade, $options);
 
-            $globals[$facade] = new Caller($facade, $options);
+            $globals[$facade] = new Caller($callable, $options);
         }
 
         return $globals;


### PR DESCRIPTION
This meant it was not possible to use an alias for a Facade in templates.

for example from the config (/rcrowe/twigbrige/extensions.php)
        'HTML' => ['is_safe' => true, 'callback'=> 'markup'],

I would expect to then be able to use 'markup' in the template, like so: {{ markup.whatever() }}
