### PR TITLE
View::share support

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -219,7 +219,8 @@ class ServiceProvider extends ViewServiceProvider
             return new Engine\Twig(
                 $this->app['twig.compiler'],
                 $this->app['twig.loader.viewfinder'],
-                $this->app['config']->get('twigbridge::twig.globals', [])
+                $this->app['config']->get('twigbridge::twig.globals', []),
+                $this->app['view']
             );
         });
     }


### PR DESCRIPTION
In Laravel, you can use View::share(key,value) to share variables to all the views. (http://laravel.com/docs/4.2/responses#views).

When I was using TwigBridge with Laravel 4.1 in my current project, It worked as I expected. Even when I used an include in Twig such as:

 {{ include(
     'partials.sidebar',
     {
         'var' : 'value'
     },  
     with_context = false
 ) }}

The View::share variables were available in the partials.sidebar template. Only View::make('template')->with(key,value) variables were subject to the with_context option.

After upgrading to Laravel 4.2 this was no longer true. View::share variables stopped being available in the included view.

This pull requests addresses this issue. I suggest using the Twig addGlobal (http://twig.sensiolabs.org/doc/advanced.html#globals) support which makes the global variables available everywhere.

I'll appreciate feedback about this issue and my suggested implementation.

Best regards,
Bruno S.
