### PR TITLE
[WIP] Use original name

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -64,6 +64,15 @@ class Bridge extends Twig_Environment
         $this->app = $app;
     }
 
+    public function loadTemplate($name, $index = null)
+    {
+        $template = parent::loadTemplate($name, $index);
+
+        $template->setName($this->normalizeName($name));
+
+        return $template;
+    }
+
     /**
      * Lint (check) the syntax of a file on the view paths.
      *
@@ -106,5 +115,24 @@ class Bridge extends Twig_Environment
         }
 
         return $context;
+    }
+
+    /**
+     * Normalize a view name.
+     *
+     * @param  string $name
+     *
+     * @return string
+     */
+    protected function normalizeName($name)
+    {
+        $extension = '.' . $this->app['twig.extension'];
+        $length = strlen($extension);
+
+        if (substr($name, -$length, $length) === $extension) {
+            $name = substr($name, 0, -$length);
+        }
+
+        return $name;
     }
 }

--- a/src/Twig/Template.php
+++ b/src/Twig/Template.php
@@ -23,6 +23,7 @@ abstract class Template extends Twig_Template
      * @var bool Have the creator/composer events fired.
      */
     protected $firedEvents = false;
+    protected $name = null;
 
     /**
      * {@inheritdoc}
@@ -53,12 +54,12 @@ abstract class Template extends Twig_Template
             return $context;
         }
 
-        /** @var \Illuminate\View\Factory $env */
+        /** @var \Illuminate\View\Factory $factory */
         $env  = $context['__env'];
         $view = new View(
             $env,
             $env->getEngineResolver()->resolve('twig'),
-            $this->getNormalizedName($env),
+            $this->name,
             null,
             $context
         );
@@ -68,26 +69,13 @@ abstract class Template extends Twig_Template
     }
 
     /**
-     * Get the normalized name, for creator/composer events
-     *
-     * @param  \Illuminate\View\Factory $viewEnvironment
-     * @return string
+     * Set the name of this template, as called by the developer.
      */
-    protected function getNormalizedName($viewEnvironment)
+    public function setName($name)
     {
-        $paths = $viewEnvironment->getFinder()->getPaths();
-        $name = $this->getTemplateName();
-
-        // Replace absolute paths, trim slashes, remove extension
-        $name = str_replace($paths, '', $name);
-        $name = ltrim($name, '/');
-
-        if (substr($name, -5, 5) === '.twig') {
-            $name = substr($name, 0, -5);
-        }
-
-        return $name;
+        $this->name = $name;
     }
+
 
     /**
      * Determine whether events should fire for this view.


### PR DESCRIPTION
This PR should add the template name to the Template class, as it is called by the user. This prevents having to use the `getTemplateName()`, which isn't reliable because it's only created once, when compiling the template.
This doesn't work for the template from View::make() but that doesn't need the original name, as events are already called.

Things to think about is normalizing the view. Previously, the view was normalized to use slashes. This PR would revert that to exactly what the user enters. And since this commit in L5, paths are normalized to use dots instead of slashes: https://github.com/laravel/framework/commit/950e1b53520183137eb753f4b28d598bb0280cff

So what do you think? Normalize to `/`, `.` or just keep as they are entered? In L5 they will be normalized anyways so it might be better to use the dot notation already.
