### PR TITLE
Fix issue with view composers and creators not being fired on includes

### DIFF
--- a/src/Twig/Template.php
+++ b/src/Twig/Template.php
@@ -56,10 +56,11 @@ abstract class Template extends Twig_Template
 
         /** @var \Illuminate\View\Factory $factory */
         $env  = $context['__env'];
+        $view_name = empty($this->name) ? $this->getTemplateName() : $this->name;
         $view = new View(
             $env,
             $env->getEngineResolver()->resolve('twig'),
-            $this->name,
+            $view_name,
             null,
             $context
         );

--- a/src/Twig/Template.php
+++ b/src/Twig/Template.php
@@ -56,11 +56,11 @@ abstract class Template extends Twig_Template
 
         /** @var \Illuminate\View\Factory $factory */
         $env  = $context['__env'];
-        $view_name = empty($this->name) ? $this->getTemplateName() : $this->name;
+        $viewName = $this->name ?: $this->getTemplateName();
         $view = new View(
             $env,
             $env->getEngineResolver()->resolve('twig'),
-            $view_name,
+            $viewName,
             null,
             $context
         );


### PR DESCRIPTION
The name is not always set, meaning the view composers and creators are not being called correctly on 

```{% include "xyz" %}``` 

If no name is set on the Template object (``$this``) then use ``getTemplateName()``.