### PR TITLE
Missing csrf_token parameter in Form extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Allows you to use [Twig](http://twig.sensiolabs.org/) seamlessly in [Laravel 4](
 [![Coverage Status](https://coveralls.io/repos/rcrowe/TwigBridge/badge.png?branch=0.6)](https://coveralls.io/r/rcrowe/TwigBridge?branch=0.6)
 [![License](https://poser.pugx.org/rcrowe/twigbridge/license.png)](https://packagist.org/packages/rcrowe/twigbridge)
 
+### For Laravel 5.0, use the [0.7 branch](https://github.com/rcrowe/TwigBridge/tree/0.7)
 # Requirements
 
 TwigBridge >=0.6 requires PHP 5.4+ & Laravel 4.1+.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Twig::render('mytemplate', $data);
 
 # Configuration
 
-TwigBridge's configuration file can be extended by creating `app/config/packages/rcrowe/twigbridge/config.php`. You can find the default configuration file at vendor/rcrowe/twigbridge/src/config/config.php.
+TwigBridge's configuration file can be extended by creating `app/config/packages/rcrowe/twigbridge/twig.php` and `extensions.php`. You can find the default configuration file at vendor/rcrowe/twigbridge/src/config/.
 
 You can quickly publish a configuration file by running the following Artisan command.
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -210,6 +210,8 @@ class ServiceProvider extends ViewServiceProvider
             },
             true
         );
+        
+        $this->app->alias('twig', 'TwigBridge\Bridge');
 
         $this->app->bindIf('twig.compiler', function () {
             return new Engine\Compiler($this->app['twig']);


### PR DESCRIPTION
Hi,

The new 'register' for the form extension should be
<pre>
public function register()
	{
		$this->app->bind('Collective\Html\FormBuilder', function () {

            return new \Collective\Html\FormBuilder(
                $this->app->make('Collective\Html\HtmlBuilder'),
                $this->app->make('Illuminate\Routing\UrlGenerator'),
                csrf_token()
            );

        });
	}
</pre>
