### PR TITLE
Add Lumen Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "laravelcollective/html": "For bringing back html/form in Laravel 5.x"
     },
     "autoload": {
+        "files": [
+            "src/LumenHelpers.php"
+        ],
         "psr-4": {
             "TwigBridge\\": "src",
             "TwigBridge\\Tests\\": "tests"

--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -13,7 +13,7 @@ namespace TwigBridge;
 
 use Twig_Environment;
 use Twig_LoaderInterface;
-use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Foundation\Application;
 use InvalidArgumentException;
 use Twig_Error;
 

--- a/src/LumenHelpers.php
+++ b/src/LumenHelpers.php
@@ -1,0 +1,15 @@
+<?php
+
+if ( ! function_exists('config_path'))
+{
+    /**
+     * Get the configuration path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function config_path($path = '')
+    {
+        return base_path('config' . ($path ? '/'.$path : $path));
+    }
+}


### PR DESCRIPTION
Addresses issue #195 by adding support for Lumen.  I changed the `TwigBridge` constructor to use the `Illuminate\Foundation\Application` contract rather than the concrete implemenation and I added the `config_path` helper as Lumen doesn't have it by default, unlike Laravel.

In order for `TwigBridge` to work in Lumen, the following Extensions need to be removed from the config: `TwigBridge\Extension\Laravel\Auth`, `TwigBridge\Extension\Laravel\Translator`, and `TwigBridge\Extension\Laravel\Url`.  To do this, I created a `config` folder in the root directory, and created a file called `twigbridge.php` and added the following:

```php
return [
    'extensions' => [
        'enabled' => [
            'TwigBridge\Extension\Loader\Facades',
            'TwigBridge\Extension\Loader\Filters',
            'TwigBridge\Extension\Loader\Functions',

            //'TwigBridge\Extension\Laravel\Auth',
            'TwigBridge\Extension\Laravel\Config',
            'TwigBridge\Extension\Laravel\Dump',
            'TwigBridge\Extension\Laravel\Input',
            'TwigBridge\Extension\Laravel\Session',
            'TwigBridge\Extension\Laravel\String',
            //'TwigBridge\Extension\Laravel\Translator',
            //'TwigBridge\Extension\Laravel\Url'
        ]
    ]  
];
```

In order to load this config file into Lumen, you need to do:

```php
/**
 * Set up TwigBridge
 */
$this->app->configure('twigbridge');
$this->app->register('TwigBridge\ServiceProvider');
```