### PR TITLE
Merge Twig global scope with Laravel Globals

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -124,6 +124,28 @@ class Bridge extends Environment
     }
 
     /**
+     * Merges a context with the defined globals.
+     *
+     * @param array $context An array representing the context
+     *
+     * @return array The context merged with the globals
+     */
+    public function mergeGlobals(array $context)
+    {
+        $context = parent::mergeGlobals($context);
+
+        // we don't use array_merge as the context being generally
+        // bigger than globals, this code is faster.
+        foreach ($this->app['view']->getShared() as $key => $value) {
+            if (!array_key_exists($key, $context)) {
+                $context[$key] = $value;
+            }
+        }
+
+        return $context;
+    }
+
+    /**
      * Normalize a view name.
      *
      * @param  string $name


### PR DESCRIPTION
When you import a template that contains macros, then call one of those macros, they do not have access to the Laravel view globals such as "errors". This patch fixes that.

The code is duplicate of that from Bridge::mergeShared(). The logic in mergeShared might be able to be removed.
