### PR TITLE
Check if alias is already registered before creating the alias

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -279,7 +279,7 @@ class ServiceProvider extends ViewServiceProvider
      */
     protected function registerAliases()
     {
-        if (!$this->isRunningOnPhp7()) {
+        if (!$this->isRunningOnPhp7() and !class_exists('TwigBridge\Extension\Laravel\String')) {
             class_alias('TwigBridge\Extension\Laravel\Str', 'TwigBridge\Extension\Laravel\String');
         }
     }


### PR DESCRIPTION
In commit 2d57cd6b7b7e6cd4a1ed9246d4bf1087785e5fc4 new code is added that creates a alias. When using default [Laravel TestCase](https://github.com/laravel/laravel/blob/master/tests/TestCase.php) this alias code causes the following crash:
`cannot redeclare class TwigBridge\Extension\Laravel\String`.
When adding a `class_exists` statement to check if the alias already exist, this error is fixed.

EDIT: this is a fix for issue https://github.com/rcrowe/TwigBridge/issues/229