### PR TITLE
Avoid deprecation errors for twig ^1.23.0

### DIFF
--- a/src/Extension/Loader/Facades.php
+++ b/src/Extension/Loader/Facades.php
@@ -12,6 +12,7 @@
 namespace TwigBridge\Extension\Loader;
 
 use TwigBridge\Extension\Loader\Facade\Caller;
+use TwigBridge\Twig\Globals;
 
 /**
  * Extension to expose defined facades to the Twig templates.
@@ -26,7 +27,7 @@ use TwigBridge\Extension\Loader\Facade\Caller;
  *     {{ Config.get('app.timezone') }}
  * </code>
  */
-class Facades extends Loader
+class Facades extends Loader implements Globals
 {
     /**
      * {@inheritDoc}

--- a/src/Twig/Globals.php
+++ b/src/Twig/Globals.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the TwigBridge package.
+ *
+ * @copyright Robert Crowe <hello@vivalacrowe.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace TwigBridge\Twig;
+
+if (version_compare(\Twig_Environment::VERSION, '1.23.0') === -1) {
+    interface Globals
+    {
+    }
+} else {
+    interface Globals extends \Twig_Extension_GlobalsInterface
+    {
+    }
+}


### PR DESCRIPTION
### Fixed

- Prevent twig_environment versions ^1.23 to trigger errors and keep being compatible with all ^1.15 versions.

--
This deprecation error:

- https://github.com/twigphp/Twig/blob/1.x/CHANGELOG#L13
- https://github.com/twigphp/Twig/blob/093bf70d6ccb6033772dd7160354b822dcc87c26/lib/Twig/Environment.php#L1272

Same solution as:

https://github.com/symfony/symfony/blob/9d1072d0706af30b5649fee3deb65bc536a08b2a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php

and

https://github.com/aws/aws-sdk-php/blob/2.8/src/Aws/DynamoDb/Session/SessionHandlerInterface.php

Tested with twig/twig version `1.15.0` (lowest), `1.22.3`, `1.23.0` and `1.23.1`