### PR TITLE
Include "guard" method in Auth extension

### DIFF
--- a/src/Extension/Laravel/Auth.php
+++ b/src/Extension/Laravel/Auth.php
@@ -52,6 +52,7 @@ class Auth extends Twig_Extension
             new Twig_SimpleFunction('auth_check', [$this->auth, 'check']),
             new Twig_SimpleFunction('auth_guest', [$this->auth, 'guest']),
             new Twig_SimpleFunction('auth_user', [$this->auth, 'user']),
+            new Twig_SimpleFunction('auth_guard', [$this->auth, 'guard']),
         ];
     }
 }


### PR DESCRIPTION
Enables the "guard" method of the AuthManager, which is required if the auth configuration uses more than one authentication method.