### PR TITLE
Fix debug to work as expected

### DIFF
--- a/config/twigbridge.php
+++ b/config/twigbridge.php
@@ -38,7 +38,7 @@ return [
             // When set to true, the generated templates have a __toString() method
             // that you can use to display the generated nodes.
             // default: false
-            'debug' => config('app.debug', false),
+            'debug' => env('APP_DEBUG', false),
 
             // The charset used by the templates.
             // default: utf-8


### PR DESCRIPTION
When Laravel imports the configs, it seems to have no access to another config, therefore config('app.debug') does not deliver true even when in Debug mode. Using the environment variable instead solves the issue.