### PR TITLE
Fix issue when using the lint command

### DIFF
--- a/src/Command/Lint.php
+++ b/src/Command/Lint.php
@@ -93,7 +93,9 @@ class Lint extends Command
                 $template .= fread(STDIN, 1024);
             }
 
-            return $this->display([$this->validate($template)], $format);
+            if (!empty($template)) {
+                return $this->display([$this->validate($template)], $format);
+            }
         }
 
         $files   = $this->getFiles($this->argument('filename'), $this->option('file'), $this->option('directory'));


### PR DESCRIPTION
When using the `php artisan twig:lint` command on our Gitlab CI (docker instance), I always had this output (wile having 97 templates, and errors) :

```
$ php artisan twig:lint --verbose
OK
1/1 valid files
```

I realized that an empty string was in STDIN, blocking the lint of all templates.
Checking if the template given in STDIN is empty fixed the issue.
