### PR TITLE
Laravel-generated URLs no longer considerated safe

### DIFF
--- a/src/Extension/Laravel/Url.php
+++ b/src/Extension/Laravel/Url.php
@@ -57,13 +57,13 @@ class Url extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('asset', [$this->url, 'asset'], ['is_safe' => ['html']]),
-            new Twig_SimpleFunction('action', [$this->url, 'action'], ['is_safe' => ['html']]),
-            new Twig_SimpleFunction('url', [$this, 'url'], ['is_safe' => ['html']]),
-            new Twig_SimpleFunction('route', [$this->url, 'route'], ['is_safe' => ['html']]),
-            new Twig_SimpleFunction('route_has', [$this->router, 'has'], ['is_safe' => ['html']]),
-            new Twig_SimpleFunction('secure_url', [$this->url, 'secure'], ['is_safe' => ['html']]),
-            new Twig_SimpleFunction('secure_asset', [$this->url, 'secureAsset'], ['is_safe' => ['html']]),
+            new Twig_SimpleFunction('asset', [$this->url, 'asset']),
+            new Twig_SimpleFunction('action', [$this->url, 'action']),
+            new Twig_SimpleFunction('url', [$this, 'url']),
+            new Twig_SimpleFunction('route', [$this->url, 'route']),
+            new Twig_SimpleFunction('route_has', [$this->router, 'has']),
+            new Twig_SimpleFunction('secure_url', [$this->url, 'secure']),
+            new Twig_SimpleFunction('secure_asset', [$this->url, 'secureAsset']),
             new Twig_SimpleFunction(
                 'url_*',
                 function ($name) {


### PR DESCRIPTION
The Url extension that TwigBridge comes with defines all URLs generated with Laravel helper methods as safe - like `route(...)`, `url(...)`, `asset(...)` etc.

This causes invalid HTML. For example, in my URL `https://www.example.com/search?term=ice+hotel&filter=itinerary` the ampersand was not properly encoded to **`&amp;`** as in `https://www.example.com/search?term=ice+hotel&amp;filter=itinerary`.

Attached pull request fixes that.
