### PR TITLE
Add support for guards in Laravel Auth extention

### DIFF
--- a/src/Extension/Laravel/Auth.php
+++ b/src/Extension/Laravel/Auth.php
@@ -49,10 +49,27 @@ class Auth extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('auth_check', [$this->auth, 'check']),
-            new Twig_SimpleFunction('auth_guest', [$this->auth, 'guest']),
-            new Twig_SimpleFunction('auth_user', [$this->auth, 'user']),
+            new Twig_SimpleFunction('auth_check', $this->generateCallable('check')),
+            new Twig_SimpleFunction('auth_guest', $this->generateCallable('guest')),
+            new Twig_SimpleFunction('auth_user', $this->generateCallable('user')),
             new Twig_SimpleFunction('auth_guard', [$this->auth, 'guard']),
         ];
+    }
+
+    /**
+     * Generates a callable using a guard for the AuthManager
+     *
+     * @param $methodName
+     *
+     * @return \Closure
+     */
+    private function generateCallable($methodName)
+    {
+        return function ($guard = 'web') use ($methodName) {
+            $params = func_get_args();
+            $guard = array_shift($params);
+
+            return $this->auth->guard($guard)->$methodName($params);
+        };
     }
 }


### PR DESCRIPTION
Via this you can use different guards without having to use the `auth_guard` function all the time.

```twig
auth_guard('admin')->user()

{# becomes #}

auth_user('admin')
```

Syntax is the same for the other two.