### PR TITLE
Add autoload-dev block to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,11 @@
     },
     "autoload": {
         "psr-4": {
-            "TwigBridge\\": "src",
+            "TwigBridge\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "TwigBridge\\Tests\\": "tests"
         }
     },


### PR DESCRIPTION
This will only autoload the test suite if the package is pulled in with dev dependencies. Otherwise, it'll ignore it entirely.
