### PR TITLE
Twig_Error_Loader missing

### DIFF
--- a/src/Engine/Twig.php
+++ b/src/Engine/Twig.php
@@ -14,6 +14,7 @@ namespace TwigBridge\Engine;
 use Illuminate\View\Engines\CompilerEngine;
 use TwigBridge\Twig\Loader;
 use Twig_Error;
+use Twig_Error_Loader;
 use ErrorException;
 
 /**


### PR DESCRIPTION
Add ``use Twig_Error_Loader;`` otherwise ``catch Twig_Error_Loader`` (line 117) is never caught and falls through.