### PR TITLE
Retain original Twig_Error class

### DIFF
--- a/src/Engine/Twig.php
+++ b/src/Engine/Twig.php
@@ -15,7 +15,7 @@ use Illuminate\View\Engines\CompilerEngine;
 use TwigBridge\Twig\Loader;
 use Twig_Error;
 use Twig_Error_Loader;
-use ErrorException;
+use ReflectionClass;
 
 /**
  * View engine for Twig files.
@@ -119,8 +119,14 @@ class Twig extends CompilerEngine
             }
         }
 
-        if (isset($file)) {
-            $ex = new ErrorException($ex->getMessage(), 0, 1, $file, $templateLine, $ex);
+        if (isset($file) && $file !== $templateFile) {            
+
+            $reflection = new ReflectionClass($ex);
+
+            $property = $reflection->getProperty('filename');
+            $property->setAccessible(true);
+            $property->setValue($ex, $file);
+
         }
 
         throw $ex;


### PR DESCRIPTION
Converting the `Twig_Error` into a generic `ErrorException` prevents debugging of the _actual_ error. It also strips the helpful methods on the `Twig_Error` class and its subclasses (such as `getFilterName()`, `getMethodName()` and `getTagName()` on the various `Twig_Sandbox_SecurityError` subclasses).
