### PR TITLE
Replace usage of deprecated Twig_Error::getTemplateFile()

### DIFF
--- a/src/Engine/Twig.php
+++ b/src/Engine/Twig.php
@@ -105,15 +105,15 @@ class Twig extends CompilerEngine
      */
     protected function handleTwigError(Twig_Error $ex)
     {
-        $templateFile = $ex->getTemplateFile();
+        $templateName = $ex->getTemplateName();
         $templateLine = $ex->getTemplateLine();
 
-        if ($templateFile && file_exists($templateFile)) {
-            $file = $templateFile;
-        } elseif ($templateFile) {
+        if ($templateName && file_exists($templateName)) {
+            $file = $templateName;
+        } elseif ($templateName) {
             // Attempt to locate full path to file
             try {
-                $file = $this->loader->findTemplate($templateFile);
+                $file = $this->loader->findTemplate($templateName);
             } catch (Twig_Error_Loader $exception) {
                 // Unable to load template
             }


### PR DESCRIPTION
As per this commit in the twig getTemplateFile is now deprecated:

https://github.com/twigphp/Twig/commit/b399ec0d1a1cb260a0a5afa2fc7de46e11db6bae

Updated the usage to use the replacement method getTemplateName()