### PR TITLE
Allow the url generator object to be returned if no path is passed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": ">=5.4.0",
         "twig/twig": "~1.15|~2.0",
-        "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*",
-        "illuminate/view": "5.0.*|5.1.*|5.2.*|5.3.*"
+        "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*",
+        "illuminate/view": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*"
     },
     "require-dev": {
         "laravel/framework": "5.0.*",

--- a/src/Extension/Laravel/Url.php
+++ b/src/Extension/Laravel/Url.php
@@ -78,6 +78,10 @@ class Url extends Twig_Extension
 
     public function url($path = null, $parameters = [], $secure = null)
     {
+        if (! $path) {
+            return $this->url;
+        }
+
         return $this->url->to($path, $parameters, $secure);
     }
 }


### PR DESCRIPTION
The main use case i have for this is to when i have macros registered it also maintains consistency with the framework helper `url()`.