### PR TITLE
Check if alias is already registered

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -244,7 +244,7 @@ class ServiceProvider extends ViewServiceProvider
      */
     protected function registerAliases()
     {
-        if (!$this->isRunningOnPhp7()) {
+        if (!$this->isRunningOnPhp7() && !class_exists('TwigBridge\Extension\Laravel\String')) {
             class_alias('TwigBridge\Extension\Laravel\Str', 'TwigBridge\Extension\Laravel\String');
         }
     }


### PR DESCRIPTION
Upgrading from v0.6.1 to v0.6.2 causes the following error; Cannot redeclare class TwigBridge\Extension\Laravel\String