### PR TITLE
Add handle to commands

### DIFF
--- a/src/Command/Clean.php
+++ b/src/Command/Clean.php
@@ -47,4 +47,11 @@ class Clean extends Command
             $this->info('Twig cache cleaned');
         }
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function handle() {
+        return $this->fire();
+    }
 }

--- a/src/Command/Lint.php
+++ b/src/Command/Lint.php
@@ -390,4 +390,11 @@ class Lint extends Command
             ],
         ];
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function handle() {
+        return $this->fire();
+    }
 }

--- a/src/Command/TwigBridge.php
+++ b/src/Command/TwigBridge.php
@@ -44,4 +44,11 @@ class TwigBridge extends Command
         $this->line('<info>Twig</info> version        <comment>'.Twig_Environment::VERSION.'</comment>');
         $this->line('<info>Twig Bridge</info> version <comment>'.Bridge::BRIDGE_VERSION.'</comment>');
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function handle() {
+        return $this->fire();
+    }
 }


### PR DESCRIPTION
Adds the fix proposed by @renebakx in #318.

> I just noticed that the package breaks with 5.5-dev because the fire method was changed into handle. (see https://laravel.com/docs/master/upgrade)
> 
> [ReflectionException]
> Method TwigBridge\Command\TwigBridge::handle() does not exist
> I'am not a hardcore Laravel developer, but adding this to the 3 commands (TwigBridge,Clean and Lint) fixed my reflection errors after I upgraded from 5.4 -> 5.5 issue.
> 
> Guess this way the same package can be used by 5.4 and 5.5.
> 
> public function handle() {
>     return $this->fire();
>   }

P.S. - Not entirely sure how to fill out pull requests on github.  So any suggestions or tips are appreciated.