### PR TITLE
Add customize instruction section in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ Global variables:
  * app: the Illuminate\Foundation\Application object
  * errors: The $errors MessageBag from the Validator (always available)
 
+## Customize your Facades/Functions/Filters
+
+If you like to customize your own, check out the instruction comments of each section in `config/twigbridge.php`.
+
 # Artisan Commands
 
 TwigBridge offers a command for CLI Interaction.


### PR DESCRIPTION
Since I started to figure how to customize my own filters, there have no explicit instructions described it in README file; Then I found that few issues (#83, #142) talking about the same question as well.

And I also found that @barryvdh did point that out within issue #83, said there are instructions written in the section of the config file, so I think it is worth to place a hint in README file; Which could save lots of time for other developers.