### PR TITLE
Allow use of multiple extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Route::get('/', function () {
 });
 ```
 
-You can create the twig files in resources/views with the .twig file extension. 
+You can create the twig files in resources/views with the `.twig` or `.html.twig` file extension. 
 ```bash
 resources/views/hello.twig
 ```

--- a/config/twigbridge.php
+++ b/config/twigbridge.php
@@ -17,13 +17,13 @@ return [
     'twig' => [
         /*
         |--------------------------------------------------------------------------
-        | Extension
+        | File Extensions
         |--------------------------------------------------------------------------
         |
-        | File extension for Twig view files.
+        | File extensions for Twig view files.
         |
         */
-        'extension' => 'twig',
+        'file_extensions' => ['twig', 'html.twig'],
 
         /*
         |--------------------------------------------------------------------------
@@ -210,7 +210,7 @@ return [
         |
         */
         'filters' => [
-            'get' => 'data_get',    
+            'get' => 'data_get',
         ],
-    ],  
+    ],
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -47,7 +47,7 @@ class ServiceProvider extends ViewServiceProvider
     public function boot()
     {
         $this->loadConfiguration();
-        $this->registerExtension();
+        $this->registerExtensions();
     }
 
     /**
@@ -91,15 +91,16 @@ class ServiceProvider extends ViewServiceProvider
      *
      * @return void
      */
-    protected function registerExtension()
+    protected function registerExtensions()
     {
-        $this->app['view']->addExtension(
-            $this->app['twig.extension'],
-            'twig',
-            function () {
+        /** @var \Illuminate\View\Factory $view */
+        $view = $this->app['view'];
+
+        foreach ($this->app['twig.file_extensions'] as $extension) {
+            $view->addExtension($extension, 'twig', function () {
                 return $this->app['twig.engine'];
-            }
-        );
+            });
+        }
     }
 
     /**
@@ -137,6 +138,10 @@ class ServiceProvider extends ViewServiceProvider
     {
         $this->app->bindIf('twig.extension', function () {
             return $this->app['config']->get('twigbridge.twig.extension');
+        });
+
+        $this->app->bindIf('twig.file_extensions', function () {
+            return $this->app['config']->get('twigbridge.twig.file_extensions');
         });
 
         $this->app->bindIf('twig.options', function () {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -98,7 +98,10 @@ class ServiceProvider extends ViewServiceProvider
         /** @var \Illuminate\View\Factory $view */
         $view = $this->app['view'];
 
-        foreach ($this->app['twig.file_extensions'] as $extension) {
+        /** @var array $extensions */
+        $extensions = $this->app['twig.file_extensions'];
+
+        foreach ($extensions as $extension) {
             $view->addExtension($extension, 'twig', function () {
                 return $this->app['twig.engine'];
             });
@@ -145,7 +148,7 @@ class ServiceProvider extends ViewServiceProvider
             return new DefaultNormalizer($this->app['twig.file_extensions']);
         });
 
-        $this->app->alias('twig.normalizer', Normalizer::class);
+        $this->app->alias(Normalizer::class, 'twig.normalizer');
 
         $this->app->bindIf('twig.options', function () use ($config) {
             $options = $config->get('twigbridge.twig.environment', []);
@@ -190,7 +193,7 @@ class ServiceProvider extends ViewServiceProvider
         });
 
         $this->app->bindIf('twig.loader.viewfinder', function () {
-            return new Twig\Loader($this->app['files'], $this->app['view']->getFinder(), $this->app['twig.extension']);
+            return new Twig\Loader($this->app['files'], $this->app['view']->getFinder(), $this->app['twig.normalizer']);
         });
 
         $this->app->bindIf('twig.loader', function () {

--- a/src/Twig/Loader.php
+++ b/src/Twig/Loader.php
@@ -11,11 +11,11 @@
 
 namespace TwigBridge\Twig;
 
-use Twig_LoaderInterface;
-use Twig_Error_Loader;
-use InvalidArgumentException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\ViewFinderInterface;
+use InvalidArgumentException;
+use Twig_Error_Loader;
+use Twig_LoaderInterface;
 
 /**
  * Basic loader using absolute paths.
@@ -32,10 +32,7 @@ class Loader implements Twig_LoaderInterface
      */
     protected $finder;
 
-    /**
-     * @var string Twig file extension.
-     */
-    protected $extension;
+    protected $normalizer;
 
     /**
      * @var array Template lookup cache.
@@ -43,15 +40,14 @@ class Loader implements Twig_LoaderInterface
     protected $cache = [];
 
     /**
-     * @param \Illuminate\Filesystem\Filesystem     $files     The filesystem
-     * @param \Illuminate\View\ViewFinderInterface  $finder
-     * @param string                                $extension Twig file extension.
+     * @param \Illuminate\Filesystem\Filesystem    $files The filesystem
+     * @param \Illuminate\View\ViewFinderInterface $finder
      */
-    public function __construct(Filesystem $files, ViewFinderInterface $finder, $extension = 'twig')
+    public function __construct(Filesystem $files, ViewFinderInterface $finder, Normalizer $normalizer)
     {
-        $this->files     = $files;
-        $this->finder    = $finder;
-        $this->extension = $extension;
+        $this->files = $files;
+        $this->finder = $finder;
+        $this->normalizer = $normalizer;
     }
 
     /**
@@ -68,7 +64,7 @@ class Loader implements Twig_LoaderInterface
             return $name;
         }
 
-        $name = $this->normalizeName($name);
+        $name = $this->normalizer->normalize($name);
 
         if (isset($this->cache[$name])) {
             return $this->cache[$name];
@@ -81,21 +77,6 @@ class Loader implements Twig_LoaderInterface
         }
 
         return $this->cache[$name];
-    }
-
-    /**
-     * Normalize the Twig template name to a name the ViewFinder can use
-     *
-     * @param  string $name Template file name.
-     * @return string The parsed name
-     */
-    protected function normalizeName($name)
-    {
-        if ($this->files->extension($name) === $this->extension) {
-            $name = substr($name, 0, - (strlen($this->extension) + 1));
-        }
-
-        return $name;
     }
 
     /**

--- a/src/Twig/Loader.php
+++ b/src/Twig/Loader.php
@@ -16,6 +16,7 @@ use Illuminate\View\ViewFinderInterface;
 use InvalidArgumentException;
 use Twig_Error_Loader;
 use Twig_LoaderInterface;
+use TwigBridge\Twig\Normalizers\Normalizer;
 
 /**
  * Basic loader using absolute paths.
@@ -32,6 +33,9 @@ class Loader implements Twig_LoaderInterface
      */
     protected $finder;
 
+    /**
+     * @var \TwigBridge\Twig\Normalizers\Normalizer
+     */
     protected $normalizer;
 
     /**
@@ -40,8 +44,9 @@ class Loader implements Twig_LoaderInterface
     protected $cache = [];
 
     /**
-     * @param \Illuminate\Filesystem\Filesystem    $files The filesystem
-     * @param \Illuminate\View\ViewFinderInterface $finder
+     * @param \Illuminate\Filesystem\Filesystem       $files The filesystem
+     * @param \Illuminate\View\ViewFinderInterface    $finder
+     * @param \TwigBridge\Twig\Normalizers\Normalizer $normalizer
      */
     public function __construct(Filesystem $files, ViewFinderInterface $finder, Normalizer $normalizer)
     {

--- a/src/Twig/Normalizers/DefaultNormalizer.php
+++ b/src/Twig/Normalizers/DefaultNormalizer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace TwigBridge\Twig\Normalizers;
+
+class DefaultNormalizer implements Normalizer
+{
+    /**
+     * @var array
+     */
+    protected $extensions;
+
+    /**
+     * @param array $extensions
+     */
+    public function __construct(array $extensions)
+    {
+        $this->extensions = $extensions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize(string $name): string
+    {
+        foreach ($this->extensions as $extension) {
+            if (!str_contains($name, $extension)) {
+                continue;
+            }
+
+            return str_before($name, $this->extension($extension));
+        }
+
+        return $name;
+    }
+
+    /**
+     * @param string $extension
+     *
+     * @return string
+     */
+    protected function extension(string $extension): string
+    {
+        return str_start($extension, '.');
+    }
+}

--- a/src/Twig/Normalizers/Normalizer.php
+++ b/src/Twig/Normalizers/Normalizer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace TwigBridge\Twig\Normalizers;
+
+interface Normalizer
+{
+    /**
+     * Remove the extension from the given file name.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public function normalize(string $name): string;
+}


### PR DESCRIPTION
This PR allows the user to define the extensions to load twig files by. The default is set as `['twig', 'html.twig']`, but the user can edit this to their desire.

I'm aware of the failing tests, but unfortunately I can't run them smoothly (see #334). Once this issue is fixed, I will work on writing tests for this feature.

I "stole" the code from @sgueyemms, he already forked and fixed the issue(s) as descibed in #246. 

**Note**: This would be a major breaking change, so at least 1.0 would have to be tagged if/when this is merged. Unless you see 0.x as "experimental", in which case this can be tagged as 0.10.