### PR TITLE
Use the correct HtmlDumper for Laravel 5.7 support

### DIFF
--- a/src/Extension/Laravel/Dump.php
+++ b/src/Extension/Laravel/Dump.php
@@ -11,8 +11,8 @@
 
 namespace TwigBridge\Extension\Laravel;
 
-use Illuminate\Support\Debug\HtmlDumper;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 /**
  * Dump a variable or the view context


### PR DESCRIPTION
Laravel 5.7 removed it's HtmlDumper as Symfony added the `dd` helper. This fixes a fatal error when using `dump` in the twig templates in 5.7.