### PR TITLE
Update HtmlDumper to use Symfony, per Laravel 5.7

### DIFF
--- a/src/Extension/Laravel/Dump.php
+++ b/src/Extension/Laravel/Dump.php
@@ -11,7 +11,7 @@
 
 namespace TwigBridge\Extension\Laravel;
 
-use Illuminate\Support\Debug\HtmlDumper;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 /**


### PR DESCRIPTION
Laravel 5.7 removes `Illuminate\Support\Debug\HtmlDumper` in favor of `Symfony\Component\VarDumper\Dumper\HtmlDumper`. This commit updates the TwigBridge dumper to match the change.