### PR TITLE
Linter issue when facing an error with Twig 2.0+

### DIFF
--- a/src/Command/Lint.php
+++ b/src/Command/Lint.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Finder\Finder;
 use Twig\Error\Error;
 use Twig\Error\LoaderError;
+use Twig\Source;
 
 /**
  * Artisan command to check the syntax of Twig templates.
@@ -329,15 +330,15 @@ class Lint extends Command
     /**
      * Grabs the surrounding lines around the exception.
      *
-     * @param string     $template Contents of Twig template.
-     * @param string|int $line     Line where the exception occurred.
-     * @param int        $context  Number of lines around the line where the exception occurred.
+     * @param \Twig\Source  $template Contents of Twig template.
+     * @param string|int    $line     Line where the exception occurred.
+     * @param int           $context  Number of lines around the line where the exception occurred.
      *
      * @return array
      */
-    protected function getContext($template, $line, $context = 3)
+    protected function getContext(Source $template, $line, $context = 3)
     {
-        $lines    = explode("\n", $template);
+        $lines    = explode("\n", $template->getCode());
         $position = max(0, $line - $context);
         $max      = min(count($lines), $line - 1 + $context);
 


### PR DESCRIPTION
Hi,
I'm facing an issue with the `twig:lint` command, that completely fails when facing an issue on my project (PHP 7.3, Laravel 5.8, Twigbridge 0.11.0, Twig 2.4.8) :
```

   ErrorException  : explode() expects parameter 2 to be string, object given

  at /project/path/vendor/rcrowe/twigbridge/src/Command/Lint.php:342
    338|          * @return array
    339|          */
    340|         protected function getContext($template, $line, $context = 3)
    341|         {
  > 342|         $lines    = explode("\n", $template);
    343|         $position = max(0, $line - $context);
    344|         $max      = min(count($lines), $line - 1 + $context);
    345| 
    346|         $result = [];

  Exception trace:

  1   explode("
", Object(Twig_Source))
      /project/path/vendor/rcrowe/twigbridge/src/Command/Lint.php:342

  2   TwigBridge\Command\Lint::getContext(Object(Twig_Source))
      /project/path/vendor/rcrowe/twigbridge/src/Command/Lint.php:303

  Please use the argument -v to see more details.
```

And this is completely logical : we pass a `Twig\Source` object (created by `\TwigBridge\Twig\Loader::getSourceContext()`) to the `validate()` method, so, in case of an exception [here](https://github.com/rcrowe/TwigBridge/blob/master/src/Command/Lint.php#L187), the `template` key contains a `Twig\Source` object, and not a string.

This pull request fetches the code from the `Twig\Source` object instead of considering `$template` is a string (it can't since Twig > 2.0).