### PR TITLE
Fixed #362

### DIFF
--- a/config/twigbridge.php
+++ b/config/twigbridge.php
@@ -110,6 +110,7 @@ return [
             'TwigBridge\Extension\Laravel\Str',
             'TwigBridge\Extension\Laravel\Translator',
             'TwigBridge\Extension\Laravel\Url',
+            // 'TwigBridge\Extension\Laravel\Model',
             // 'TwigBridge\Extension\Laravel\Gate',
 
             // 'TwigBridge\Extension\Laravel\Form',

--- a/src/Extension/Laravel/Model.php
+++ b/src/Extension/Laravel/Model.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the TwigBridge package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace TwigBridge\Extension\Laravel;
+
+use Twig\Extension\AbstractExtension;
+use TwigBridge\NodeVisitor\GetAttrAdjuster;
+
+/**
+ * Access to Laravel model properties using ArrayAccess.
+ */
+class Model extends AbstractExtension
+{
+    /**
+     * @inheritDoc
+     */
+    public function getNodeVisitors()
+    {
+        return [
+            new GetAttrAdjuster,
+        ];
+    }
+}

--- a/src/Node/GetAttrNode.php
+++ b/src/Node/GetAttrNode.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * This file is part of the TwigBridge package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace TwigBridge\Node;
+
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+use Twig\Extension\SandboxExtension;
+use Twig\Node\Expression\GetAttrExpression;
+use Twig\Node\Node;
+use Twig\Source;
+use Twig\Template;
+
+/**
+ * Compile a custom twig_get_attribute node.
+ *
+ * See:
+ *  - https://github.com/rcrowe/TwigBridge/issues/362
+ *  - https://github.com/rcrowe/TwigBridge/issues/265
+ */
+class GetAttrNode extends GetAttrExpression
+{
+    /**
+     * @inheritdoc
+     */
+    public function __construct(array $nodes = [], array $attributes = [], int $lineno = 0, string $tag = null)
+    {
+        // Skip parent::__construct()
+        Node::__construct($nodes, $attributes, $lineno, $tag);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function compile(Compiler $compiler)
+    {
+        $env = $compiler->getEnvironment();
+
+        // optimize array calls
+        if (
+            $this->getAttribute('optimizable')
+            && (!$env->isStrictVariables() || $this->getAttribute('ignore_strict_check'))
+            && !$this->getAttribute('is_defined_test')
+            && Template::ARRAY_CALL === $this->getAttribute('type')
+        ) {
+            $var = '$'.$compiler->getVarName();
+            $compiler
+                ->raw('(('.$var.' = ')
+                ->subcompile($this->getNode('node'))
+                ->raw(') && is_array(')
+                ->raw($var)
+                ->raw(') || ')
+                ->raw($var)
+                ->raw(' instanceof ArrayAccess ? (')
+                ->raw($var)
+                ->raw('[')
+                ->subcompile($this->getNode('attribute'))
+                ->raw('] ?? null) : null)')
+            ;
+
+            return;
+        }
+
+        // START EDIT
+        // This is the only line that should be different to the parent function.
+        $compiler->raw(static::class . '::attribute($this->env, $this->source, ');
+        // END EDIT
+
+        if ($this->getAttribute('ignore_strict_check')) {
+            $this->getNode('node')->setAttribute('ignore_strict_check', true);
+        }
+
+        $compiler
+            ->subcompile($this->getNode('node'))
+            ->raw(', ')
+            ->subcompile($this->getNode('attribute'))
+        ;
+
+        if ($this->hasNode('arguments')) {
+            $compiler->raw(', ')->subcompile($this->getNode('arguments'));
+        } else {
+            $compiler->raw(', []');
+        }
+
+        $compiler->raw(', ')
+            ->repr($this->getAttribute('type'))
+            ->raw(', ')->repr($this->getAttribute('is_defined_test'))
+            ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
+            ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
+            ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
+            ->raw(')')
+        ;
+    }
+
+    /**
+     * Returns the attribute value for a given array/object.
+     *
+     * @param Environment $env
+     * @param Source $source
+     * @param mixed  $object            The object or array from where to get the item
+     * @param mixed  $item              The item to get from the array or object
+     * @param array  $arguments         An array of arguments to pass if the item is an object method
+     * @param string $type              The type of attribute (@see \Twig\Template constants)
+     * @param bool   $isDefinedTest     Whether this is only a defined check
+     * @param bool   $ignoreStrictCheck Whether to ignore the strict attribute check or not
+     * @param bool   $sandboxed
+     * @param int    $lineno            The template line where the attribute was called
+     *
+     * @return mixed The attribute value, or a Boolean when $isDefinedTest is true, or null when the attribute is not set and $ignoreStrictCheck is true
+     *
+     * @throws RuntimeError if the attribute does not exist and Twig is running in strict mode and $isDefinedTest is false
+     */
+    public static function attribute(
+        Environment $env,
+        Source $source,
+        $object,
+        $item,
+        array $arguments = [],
+        $type = /* Template::ANY_CALL */ 'any',
+        $isDefinedTest = false,
+        $ignoreStrictCheck = false,
+        $sandboxed = false,
+        int $lineno = -1
+    ) {
+        if (Template::METHOD_CALL !== $type and is_a($object, 'Illuminate\Database\Eloquent\Model')) {
+            // We can't easily find out if an attribute actually exists, so return true
+            if ($isDefinedTest) {
+                return true;
+            }
+
+            if ($env->hasExtension(SandboxExtension::class)) {
+                $env->getExtension(SandboxExtension::class)->checkPropertyAllowed($object, $item);
+            }
+
+            // Call the attribute, the Model object does the rest of the magic
+            return $object->$item;
+        }
+
+        return \twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck, $sandboxed, $lineno);
+    }
+}
+

--- a/src/Node/GetAttrNode.php
+++ b/src/Node/GetAttrNode.php
@@ -111,9 +111,11 @@ class GetAttrNode extends GetAttrExpression
      * @param bool   $sandboxed
      * @param int    $lineno            The template line where the attribute was called
      *
-     * @return mixed The attribute value, or a Boolean when $isDefinedTest is true, or null when the attribute is not set and $ignoreStrictCheck is true
+     * @return mixed The attribute value, or a Boolean when $isDefinedTest is true, or null when the attribute is not
+     *               set and $ignoreStrictCheck is true
      *
-     * @throws RuntimeError if the attribute does not exist and Twig is running in strict mode and $isDefinedTest is false
+     * @throws RuntimeError if the attribute does not exist and Twig is running in strict mode
+     *         and $isDefinedTest is false
      */
     public static function attribute(
         Environment $env,
@@ -141,7 +143,17 @@ class GetAttrNode extends GetAttrExpression
             return $object->$item;
         }
 
-        return \twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck, $sandboxed, $lineno);
+        return \twig_get_attribute(
+            $env,
+            $source,
+            $object,
+            $item,
+            $arguments,
+            $type,
+            $isDefinedTest,
+            $ignoreStrictCheck,
+            $sandboxed,
+            $lineno
+        );
     }
 }
-

--- a/src/NodeVisitor/GetAttrAdjuster.php
+++ b/src/NodeVisitor/GetAttrAdjuster.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the TwigBridge package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace TwigBridge\NodeVisitor;
+
+use Twig\Environment;
+use Twig\Node\Expression\GetAttrExpression;
+use Twig\Node\Node;
+use Twig\NodeVisitor\NodeVisitorInterface;
+use TwigBridge\Node\GetAttrNode;
+
+/**
+ * Custom twig_get_attribute node.
+ */
+class GetAttrAdjuster implements NodeVisitorInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function enterNode(Node $node, Environment $env)
+    {
+        // Make sure this is a GetAttrExpression (and not a subclass)
+        if (get_class($node) !== GetAttrExpression::class) {
+            return $node;
+        }
+
+        // Swap it with our custom GetAttrNode
+        $nodes = [
+            'node' => $node->getNode('node'),
+            'attribute' => $node->getNode('attribute')
+        ];
+
+        if ($node->hasNode('arguments')) {
+            $nodes['arguments'] = $node->getNode('arguments');
+        }
+
+        $attributes = [
+            'type' => $node->getAttribute('type'),
+            'is_defined_test' => $node->getAttribute('is_defined_test'),
+            'ignore_strict_check' => $node->getAttribute('ignore_strict_check'),
+            'optimizable' => $node->getAttribute('optimizable'),
+        ];
+
+        return new GetAttrNode($nodes, $attributes, $node->getTemplateLine(), $node->getNodeTag());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function leaveNode(Node $node, Environment $env)
+    {
+        return $node;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPriority()
+    {
+        return 0;
+    }
+}

--- a/tests/Node/GetAttrTest.php
+++ b/tests/Node/GetAttrTest.php
@@ -24,8 +24,8 @@ class GetAttrTest extends NodeTestCase
          *  - src/Node/GetAttrNode.php
          */
         $this->assertEquals(
-            '79579273b68a208d25d3fbbc0206e2fe0f43ebd4',
-            sha1_file(__DIR__.'/../../composer.json')
+            '9240961010b38797cff72bc910051cbb',
+            md5_file(__DIR__.'/../../composer.json')
         );
     }
 

--- a/tests/Node/GetAttrTest.php
+++ b/tests/Node/GetAttrTest.php
@@ -2,7 +2,6 @@
 
 namespace TwigBridge\Tests\Node;
 
-use Illuminate\Database\Eloquent\Model;
 use Twig\Environment;
 use Twig\Extension\SandboxExtension;
 use Twig\Loader\LoaderInterface;
@@ -72,7 +71,17 @@ class GetAttrTest extends NodeTestCase
         $object->attr = 'test';
 
         try {
-            GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "attr", [], Template::ANY_CALL, false, false, true);
+            GetAttrNode::attribute(
+                $twig,
+                $template->getSourceContext(),
+                $object,
+                "attr",
+                [],
+                Template::ANY_CALL,
+                false,
+                false,
+                true
+            );
             $this->fail();
         } catch (SecurityError $e) {
             $this->assertContains('is not allowed', $e->getMessage());
@@ -81,7 +90,17 @@ class GetAttrTest extends NodeTestCase
         $object->attr = null;
 
         try {
-            GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "attr", [], Template::ANY_CALL, false, false, true);
+            GetAttrNode::attribute(
+                $twig,
+                $template->getSourceContext(),
+                $object,
+                "attr",
+                [],
+                Template::ANY_CALL,
+                false,
+                false,
+                true
+            );
             $this->fail();
         } catch (SecurityError $e) {
             $this->assertContains('is not allowed', $e->getMessage());
@@ -96,17 +115,39 @@ class GetAttrTest extends NodeTestCase
         $attr = new ConstantExpression('bar', 1);
         $args = new ArrayExpression([], 1);
         $node = $this->getNode($expr, $attr, $args, Template::ANY_CALL);
-        $tests[] = [$node, sprintf('%s%s, "bar", [], "any", false, false, false, 1)', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1))];
+        $tests[] = [
+            $node,
+            sprintf(
+                '%s%s, "bar", [], "any", false, false, false, 1)',
+                $this->getAttributeGetter(),
+                $this->getVariableGetter('foo', 1)
+            )
+        ];
 
         $node = $this->getNode($expr, $attr, $args, Template::ARRAY_CALL);
-        $tests[] = [$node, '(($__internal_%s = // line 1'."\n".
-                    '($context["foo"] ?? null)) && is_array($__internal_%s) || $__internal_%s instanceof ArrayAccess ? ($__internal_%s["bar"] ?? null) : null)', null, true, ];
+        $tests[] = [
+            $node,
+            '(($__internal_%s = // line 1' . "\n"
+                . '($context["foo"] ?? null))'
+                . ' && is_array($__internal_%s)'
+                . ' || $__internal_%s instanceof ArrayAccess ? ($__internal_%s["bar"] ?? null) : null)',
+            null,
+            true,
+        ];
 
         $args = new ArrayExpression([], 1);
         $args->addElement(new NameExpression('foo', 1));
         $args->addElement(new ConstantExpression('bar', 1));
         $node = $this->getNode($expr, $attr, $args, Template::METHOD_CALL);
-        $tests[] = [$node, sprintf('%s%s, "bar", [0 => %s, 1 => "bar"], "method", false, false, false, 1)', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1), $this->getVariableGetter('foo'))];
+        $tests[] = [
+            $node,
+            sprintf(
+                '%s%s, "bar", [0 => %s, 1 => "bar"], "method", false, false, false, 1)',
+                $this->getAttributeGetter(),
+                $this->getVariableGetter('foo', 1),
+                $this->getVariableGetter('foo')
+            )
+        ];
 
         return $tests;
     }
@@ -119,67 +160,13 @@ class GetAttrTest extends NodeTestCase
     protected function getNode($expr, $attr, $args, $type, $lineno = 1)
     {
         $nodes = ['node' => $expr, 'attribute' => $attr, 'arguments' => $args];
-        $attributes = ['type' => $type, 'is_defined_test' => false, 'ignore_strict_check' => false, 'optimizable' => true];
+        $attributes = [
+            'type'                  => $type,
+            'is_defined_test'       => false,
+            'ignore_strict_check'   => false,
+            'optimizable'           => true
+        ];
 
         return new GetAttrNode($nodes, $attributes, $lineno);
-    }
-}
-
-class TemplateModel extends Model
-{
-    //
-}
-
-class TemplateForTest extends Template
-{
-    private $name;
-
-    public function __construct(Environment $env, $name = 'index.twig')
-    {
-        parent::__construct($env);
-        $this->name = $name;
-    }
-
-    public function getZero()
-    {
-        return 0;
-    }
-
-    public function getEmpty()
-    {
-        return '';
-    }
-
-    public function getString()
-    {
-        return 'some_string';
-    }
-
-    public function getTrue()
-    {
-        return true;
-    }
-
-    public function getTemplateName()
-    {
-        return $this->name;
-    }
-
-    public function getDebugInfo()
-    {
-        return [];
-    }
-
-    protected function doGetParent(array $context)
-    {
-        return false;
-    }
-
-    protected function doDisplay(array $context, array $blocks = [])
-    {
-    }
-
-    public function block_name($context, array $blocks = [])
-    {
     }
 }

--- a/tests/Node/GetAttrTest.php
+++ b/tests/Node/GetAttrTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace TwigBridge\Tests\Node;
+
+use Illuminate\Database\Eloquent\Model;
+use Twig\Environment;
+use Twig\Extension\SandboxExtension;
+use Twig\Loader\LoaderInterface;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\NameExpression;
+use Twig\Sandbox\SecurityError;
+use Twig\Sandbox\SecurityPolicy;
+use Twig\Template;
+use Twig\Test\NodeTestCase;
+use TwigBridge\Node\GetAttrNode;
+
+class GetAttrTest extends NodeTestCase
+{
+    public function testComposer()
+    {
+        /*
+         * When the twig/twig dependency is updated please ensure the following files are updated:
+         *  - src/Node/GetAttrNode.php
+         */
+        $this->assertEquals(
+            '79579273b68a208d25d3fbbc0206e2fe0f43ebd4',
+            sha1_file(__DIR__.'/../../composer.json')
+        );
+    }
+
+    public function testNodeConstructor()
+    {
+        $expr = new NameExpression('foo', 1);
+        $attr = new ConstantExpression('bar', 1);
+        $args = new ArrayExpression([], 1);
+        $args->addElement(new NameExpression('foo', 1));
+        $args->addElement(new ConstantExpression('bar', 1));
+
+        $node = $this->getNode($expr, $attr, $args, Template::ARRAY_CALL);
+
+        $this->assertEquals($expr, $node->getNode('node'));
+        $this->assertEquals($attr, $node->getNode('attribute'));
+        $this->assertEquals($args, $node->getNode('arguments'));
+        $this->assertEquals(Template::ARRAY_CALL, $node->getAttribute('type'));
+    }
+
+    public function testGetAttributeOnModel()
+    {
+        $twig = new Environment($this->createMock(LoaderInterface::class));
+        $template = new TemplateForTest($twig);
+
+        $object = new TemplateModel;
+        $object->attr = 'test';
+
+        $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "attr", [], Template::ANY_CALL);
+        $this->assertEquals('test', $actual);
+
+        $object->attr = null;
+        $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "attr", [], Template::ANY_CALL);
+        $this->assertEquals(null, $actual);
+    }
+
+    public function testGetAttributeOnModelWithSandbox()
+    {
+        $twig = new Environment($this->createMock(LoaderInterface::class));
+        $policy = new SecurityPolicy([], [], [/*method*/], [/*prop*/], []);
+        $twig->addExtension(new SandboxExtension($policy, true));
+        $template = new TemplateForTest($twig);
+
+        $object = new TemplateModel;
+        $object->attr = 'test';
+
+        try {
+            GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "attr", [], Template::ANY_CALL, false, false, true);
+            $this->fail();
+        } catch (SecurityError $e) {
+            $this->assertContains('is not allowed', $e->getMessage());
+        }
+
+        $object->attr = null;
+
+        try {
+            GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "attr", [], Template::ANY_CALL, false, false, true);
+            $this->fail();
+        } catch (SecurityError $e) {
+            $this->assertContains('is not allowed', $e->getMessage());
+        }
+    }
+
+    public function getTests()
+    {
+        $tests = [];
+
+        $expr = new NameExpression('foo', 1);
+        $attr = new ConstantExpression('bar', 1);
+        $args = new ArrayExpression([], 1);
+        $node = $this->getNode($expr, $attr, $args, Template::ANY_CALL);
+        $tests[] = [$node, sprintf('%s%s, "bar", [], "any", false, false, false, 1)', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1))];
+
+        $node = $this->getNode($expr, $attr, $args, Template::ARRAY_CALL);
+        $tests[] = [$node, '(($__internal_%s = // line 1'."\n".
+                    '($context["foo"] ?? null)) && is_array($__internal_%s) || $__internal_%s instanceof ArrayAccess ? ($__internal_%s["bar"] ?? null) : null)', null, true, ];
+
+        $args = new ArrayExpression([], 1);
+        $args->addElement(new NameExpression('foo', 1));
+        $args->addElement(new ConstantExpression('bar', 1));
+        $node = $this->getNode($expr, $attr, $args, Template::METHOD_CALL);
+        $tests[] = [$node, sprintf('%s%s, "bar", [0 => %s, 1 => "bar"], "method", false, false, false, 1)', $this->getAttributeGetter(), $this->getVariableGetter('foo', 1), $this->getVariableGetter('foo'))];
+
+        return $tests;
+    }
+
+    protected function getAttributeGetter()
+    {
+        return 'TwigBridge\Node\GetAttrNode::attribute($this->env, $this->source, ';
+    }
+
+    protected function getNode($expr, $attr, $args, $type, $lineno = 1)
+    {
+        $nodes = ['node' => $expr, 'attribute' => $attr, 'arguments' => $args];
+        $attributes = ['type' => $type, 'is_defined_test' => false, 'ignore_strict_check' => false, 'optimizable' => true];
+
+        return new GetAttrNode($nodes, $attributes, $lineno);
+    }
+}
+
+class TemplateModel extends Model
+{
+    //
+}
+
+class TemplateForTest extends Template
+{
+    private $name;
+
+    public function __construct(Environment $env, $name = 'index.twig')
+    {
+        parent::__construct($env);
+        $this->name = $name;
+    }
+
+    public function getZero()
+    {
+        return 0;
+    }
+
+    public function getEmpty()
+    {
+        return '';
+    }
+
+    public function getString()
+    {
+        return 'some_string';
+    }
+
+    public function getTrue()
+    {
+        return true;
+    }
+
+    public function getTemplateName()
+    {
+        return $this->name;
+    }
+
+    public function getDebugInfo()
+    {
+        return [];
+    }
+
+    protected function doGetParent(array $context)
+    {
+        return false;
+    }
+
+    protected function doDisplay(array $context, array $blocks = [])
+    {
+    }
+
+    public function block_name($context, array $blocks = [])
+    {
+    }
+}

--- a/tests/Node/GetAttrTest.php
+++ b/tests/Node/GetAttrTest.php
@@ -16,18 +16,6 @@ use TwigBridge\Node\GetAttrNode;
 
 class GetAttrTest extends NodeTestCase
 {
-    public function testComposer()
-    {
-        /*
-         * When the twig/twig dependency is updated please ensure the following files are updated:
-         *  - src/Node/GetAttrNode.php
-         */
-        $this->assertEquals(
-            '9240961010b38797cff72bc910051cbb',
-            md5_file(__DIR__.'/../../composer.json')
-        );
-    }
-
     public function testNodeConstructor()
     {
         $expr = new NameExpression('foo', 1);

--- a/tests/Node/TemplateForTest.php
+++ b/tests/Node/TemplateForTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace TwigBridge\Tests\Node;
+
+use Twig\Environment;
+use Twig\Template;
+
+class TemplateForTest extends Template
+{
+    private $name;
+
+    public function __construct(Environment $env, $name = 'index.twig')
+    {
+        parent::__construct($env);
+        $this->name = $name;
+    }
+
+    public function getZero()
+    {
+        return 0;
+    }
+
+    public function getEmpty()
+    {
+        return '';
+    }
+
+    public function getString()
+    {
+        return 'some_string';
+    }
+
+    public function getTrue()
+    {
+        return true;
+    }
+
+    public function getTemplateName()
+    {
+        return $this->name;
+    }
+
+    public function getDebugInfo()
+    {
+        return [];
+    }
+
+    protected function doGetParent(array $context)
+    {
+        return false;
+    }
+
+    protected function doDisplay(array $context, array $blocks = [])
+    {
+    }
+}

--- a/tests/Node/TemplateModel.php
+++ b/tests/Node/TemplateModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace TwigBridge\Tests\Node;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TemplateModel extends Model
+{
+    //
+}


### PR DESCRIPTION
Fixed https://github.com/rcrowe/TwigBridge/issues/362

In v1 we were overriding the `getAttribute` function so that we could handle the twerks of Laravel's Eloquent Model class. In v2 twig replaced that with a global function. The recommend approach to handle this is described here: https://github.com/twigphp/Twig/issues/2338#issuecomment-270927461

I'm grateful to craftcms for demonstrating how to implement the node visitors! See https://github.com/craftcms/cms/commit/8bec4976bc8b75297d9b1d5c977a4a2fa9e19de4