### PR TITLE
Enable Laravel Model extension by default

### DIFF
--- a/config/twigbridge.php
+++ b/config/twigbridge.php
@@ -110,7 +110,7 @@ return [
             'TwigBridge\Extension\Laravel\Str',
             'TwigBridge\Extension\Laravel\Translator',
             'TwigBridge\Extension\Laravel\Url',
-            // 'TwigBridge\Extension\Laravel\Model',
+            'TwigBridge\Extension\Laravel\Model',
             // 'TwigBridge\Extension\Laravel\Gate',
 
             // 'TwigBridge\Extension\Laravel\Form',


### PR DESCRIPTION
As shortly discussed on https://github.com/rcrowe/TwigBridge/pull/369, i propose we make the 'Model' extension enabled by default.

@bytestream any thoughts if this shouldn't be?