### PR TITLE
Added Gate extension and can function to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ TwigBridge comes with the following extensions enabled by default:
 - TwigBridge\Extension\Laravel\Config
 - TwigBridge\Extension\Laravel\Dump
 - TwigBridge\Extension\Laravel\Form
+- TwigBridge\Extension\Laravel\Gate
 - TwigBridge\Extension\Laravel\Html
 - TwigBridge\Extension\Laravel\Input
 - TwigBridge\Extension\Laravel\Session
@@ -197,6 +198,7 @@ The following helpers/filters are added by the default Extensions. They are base
 Functions:
  * asset, action, url, route, secure_url, secure_asset
  * auth_check, auth_guest, auth_user
+ * can
  * config_get, config_has
  * dump
  * form_* (All the Form::* methods, snake_cased)


### PR DESCRIPTION
Added missing info about TwigBridge\Extension\Laravel\Gate extension in README.md, also added can function to the function list.