### PR TITLE
Add support for minor versions of 6.0 as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=7.1",
         "twig/twig": "~2.0",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.x|^6.0",
-        "illuminate/view": "5.5.*|5.6.*|5.7.*|5.8.x|6.0.*"
+        "illuminate/view": "5.5.*|5.6.*|5.7.*|5.8.x|^6.0"
     },
     "require-dev": {
         "laravel/framework": "5.5.*",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.1",
         "twig/twig": "~2.0",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.x|6.0.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.x|^6.0",
         "illuminate/view": "5.5.*|5.6.*|5.7.*|5.8.x|6.0.*"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 6.1 was released today, but the constraint prevents installing it.

To the best of my knowledge, we should allow minor versions as well with the changed semver versioning from 6.0 and up.

See https://github.com/laravel/framework/releases/tag/v6.1.0