### PR TITLE
Use laravel Translator Interface instead of implementation

### DIFF
--- a/src/Extension/Laravel/Translator.php
+++ b/src/Extension/Laravel/Translator.php
@@ -11,7 +11,7 @@
 
 namespace TwigBridge\Extension\Laravel;
 
-use Illuminate\Translation\Translator as LaravelTranslator;
+use Illuminate\Contracts\Translation\Translator as LaravelTranslator;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 use Twig\Extension\AbstractExtension;


### PR DESCRIPTION
Instead of using the Laravel Translator implementation, we should use the Interface that it implements, in this ways if someone has it owns translator (like in our case) we can still use this extension (instead of having to disable the extension and create our own)