### PR TITLE
Add ability to specify safe classes for escaper

### DIFF
--- a/config/twigbridge.php
+++ b/config/twigbridge.php
@@ -75,6 +75,19 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Safe Classes
+        |--------------------------------------------------------------------------
+        |
+        | When set, the output of the `__string` method of the following classes will not be escaped.
+        | default: Laravel's Htmlable, which the HtmlString class implements.
+        |
+        */
+        'safe_classes' => [
+            \Illuminate\Contracts\Support\Htmlable::class => ['html'],
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
         | Global variables
         |--------------------------------------------------------------------------
         |

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -16,6 +16,7 @@ use InvalidArgumentException;
 use Twig\Lexer;
 use Twig\Extension\DebugExtension;
 use Twig\Extension\ExtensionInterface;
+use Twig\Extension\EscaperExtension;
 use Twig\Loader\ArrayLoader;
 use Twig\Loader\ChainLoader;
 use Twig_Environment;
@@ -228,6 +229,10 @@ class ServiceProvider extends ViewServiceProvider
                     $this->app['twig.options'],
                     $this->app
                 );
+
+                foreach ($this->app['config']->get('twigbridge.twig.safe_classes', []) as $safeClass => $strategy) {
+                    $twig->getExtension(EscaperExtension::class)->addSafeClass($safeClass, $strategy);
+                }
 
                 // Instantiate and add extensions
                 foreach ($extensions as $extension) {


### PR DESCRIPTION
Reasoning: Laravel provides a handy `HtmlString` that implements the `Htmlable` interface. If a function in the twig template is called and such a object is returned, it should not escape the HTML.

Twig provides a handy `setSafeClass` method on the `EscaperExtension` class which is enabled by default. This PR adds the ability to define custom safe classes in the config item. By default, we set the sensable `Htmlable` with the `['html']` strategy.