### PR TITLE
Closes #388 [2]

### DIFF
--- a/src/Node/GetAttrNode.php
+++ b/src/Node/GetAttrNode.php
@@ -7,6 +7,7 @@
  */
 namespace TwigBridge\Node;
 
+use ArrayAccess;
 use Twig\Compiler;
 use Twig\Environment;
 use Twig\Error\RuntimeError;
@@ -129,7 +130,12 @@ class GetAttrNode extends GetAttrExpression
         $sandboxed = false,
         int $lineno = -1
     ) {
-        if (Template::METHOD_CALL !== $type and is_a($object, 'Illuminate\Database\Eloquent\Model')) {
+        // Twig doesn't support sandboxing on objects that implement ArrayAccess
+        //   https://github.com/twigphp/Twig/issues/106#issuecomment-583737
+        //   https://github.com/twigphp/Twig/pull/1863
+        //
+        //   https://github.com/twigphp/Twig/issues/2878
+        if (Template::METHOD_CALL !== $type and $object instanceof ArrayAccess && isset($object[$item])) {
             // We can't easily find out if an attribute actually exists, so return true
             if ($isDefinedTest) {
                 return true;
@@ -139,8 +145,8 @@ class GetAttrNode extends GetAttrExpression
                 $env->getExtension(SandboxExtension::class)->checkPropertyAllowed($object, $item);
             }
 
-            // Call the attribute, the Model object does the rest of the magic
-            return $object->$item;
+            // Call the attribute, the object does the rest of the magic
+            return $object[$item];
         }
 
         return \twig_get_attribute(

--- a/src/Node/GetAttrNode.php
+++ b/src/Node/GetAttrNode.php
@@ -135,7 +135,7 @@ class GetAttrNode extends GetAttrExpression
         //   https://github.com/twigphp/Twig/pull/1863
         //
         //   https://github.com/twigphp/Twig/issues/2878
-        if (Template::METHOD_CALL !== $type and $object instanceof ArrayAccess && isset($object[$item])) {
+        if (Template::METHOD_CALL !== $type and $object instanceof ArrayAccess) {
             // We can't easily find out if an attribute actually exists, so return true
             if ($isDefinedTest) {
                 return true;
@@ -146,7 +146,7 @@ class GetAttrNode extends GetAttrExpression
             }
 
             // Call the attribute, the object does the rest of the magic
-            return $object[$item];
+            return isset($object[$item]) ? $object[$item] : null;
         }
 
         return \twig_get_attribute(


### PR DESCRIPTION
Remake of https://github.com/rcrowe/TwigBridge/pull/398 which was reverted due to https://github.com/rcrowe/TwigBridge/pull/398#issuecomment-653434596

Before we were use checking for calls against Eloquent models. #388 is lack of sandbox checks on Container objects. 

The problem with the old PR was that it was checking `ArrayAccess` but using `$object->$item`  - see https://github.com/rcrowe/TwigBridge/pull/398#issuecomment-653512286

This PR resolves that issue by using `$object[$item]` and also adds the `isset()` check which happens in the upstream code - https://github.com/twigphp/Twig/blob/3.x/src/Extension/CoreExtension.php#L1370

