### PR TITLE
Revert "Closes #388 [2] (#401)"

### DIFF
--- a/src/Node/GetAttrNode.php
+++ b/src/Node/GetAttrNode.php
@@ -7,7 +7,6 @@
  */
 namespace TwigBridge\Node;
 
-use ArrayAccess;
 use Twig\Compiler;
 use Twig\Environment;
 use Twig\Error\RuntimeError;
@@ -130,12 +129,7 @@ class GetAttrNode extends GetAttrExpression
         $sandboxed = false,
         int $lineno = -1
     ) {
-        // Twig doesn't support sandboxing on objects that implement ArrayAccess
-        //   https://github.com/twigphp/Twig/issues/106#issuecomment-583737
-        //   https://github.com/twigphp/Twig/pull/1863
-        //
-        //   https://github.com/twigphp/Twig/issues/2878
-        if (Template::METHOD_CALL !== $type and $object instanceof ArrayAccess) {
+        if (Template::METHOD_CALL !== $type and is_a($object, 'Illuminate\Database\Eloquent\Model')) {
             // We can't easily find out if an attribute actually exists, so return true
             if ($isDefinedTest) {
                 return true;
@@ -145,8 +139,8 @@ class GetAttrNode extends GetAttrExpression
                 $env->getExtension(SandboxExtension::class)->checkPropertyAllowed($object, $item);
             }
 
-            // Call the attribute, the object does the rest of the magic
-            return isset($object[$item]) ? $object[$item] : null;
+            // Call the attribute, the Model object does the rest of the magic
+            return $object->$item;
         }
 
         return \twig_get_attribute(


### PR DESCRIPTION
This reverts commit 35559329

- - -

Doesn't work properties on an object e.g. `$model->exists` 

- - -

It's too fiddly and lack of tests. Not changing it again. Suggest to go the way of https://github.com/rcrowe/TwigBridge/pull/403 instead