### PR TITLE
Add test to ensure that the model exists method can be used

### DIFF
--- a/tests/Node/GetAttrTest.php
+++ b/tests/Node/GetAttrTest.php
@@ -46,6 +46,13 @@ class GetAttrTest extends NodeTestCase
         $object->attr = null;
         $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "attr", [], Template::ANY_CALL);
         $this->assertEquals(null, $actual);
+
+        $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "exists", [], Template::ANY_CALL);
+        $this->assertEquals(false, $actual);
+
+        $object->exists = true;
+        $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "exists", [], Template::ANY_CALL);
+        $this->assertEquals(true, $actual);
     }
 
     public function testGetAttributeOnModelWithSandbox()


### PR DESCRIPTION
Adds a (failing) test that the Model's exists method can be used in templates. 

When #405 is merged, this test will succeed and prevent breakage in the future.