### PR TITLE
Remove optional arguments to fix max line characters

### DIFF
--- a/tests/Node/GetAttrTest.php
+++ b/tests/Node/GetAttrTest.php
@@ -47,11 +47,11 @@ class GetAttrTest extends NodeTestCase
         $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "attr", [], Template::ANY_CALL);
         $this->assertEquals(null, $actual);
 
-        $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "exists", [], Template::ANY_CALL);
+        $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "exists");
         $this->assertEquals(false, $actual);
 
         $object->exists = true;
-        $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "exists", [], Template::ANY_CALL);
+        $actual = GetAttrNode::attribute($twig, $template->getSourceContext(), $object, "exists");
         $this->assertEquals(true, $actual);
     }
 


### PR DESCRIPTION
Fixes comment from #406

These parameters are optional as these are the default values.