### PR TITLE
Fix PHP 8 TypeError

### DIFF
--- a/src/Extension/Loader/Facade/Caller.php
+++ b/src/Extension/Loader/Facade/Caller.php
@@ -86,7 +86,7 @@ class Caller
         }
 
         $result  = forward_static_call_array([$this->facade, $method], $arguments);
-        $is_safe = ($is_safe && (is_string($result) || method_exists($result, '__toString')));
+        $is_safe = ($is_safe && (is_string($result) || (is_callable($result) && method_exists($result, '__toString'))));
 
         return ($is_safe) ? new Markup($result, $this->options['charset']) : $result;
     }

--- a/tests/Extension/Loader/Facade/CallerTest.php
+++ b/tests/Extension/Loader/Facade/CallerTest.php
@@ -2,8 +2,9 @@
 
 namespace TwigBridge\Tests\Extension\Loader\Facade;
 
+use Illuminate\Support\Facades\Config;
+use Twig\Markup;
 use TwigBridge\Tests\Base;
-use Mockery as m;
 use TwigBridge\Extension\Loader\Facade\Caller;
 
 class CallerTest extends Base
@@ -18,5 +19,23 @@ class CallerTest extends Base
             'charset' => null,
             'name'    => 'Rob',
         ]);
+    }
+
+    public function testSafeMagicMethods(): void
+    {
+        $app = $this->getApplication();
+        Config::setFacadeApplication($app);
+        $caller = new Caller(Config::class, ['is_safe' => true]);
+
+        $this->assertNotInstanceOf(Markup::class, $caller->all());
+    }
+
+    public function testUnsafeMagicMethods(): void
+    {
+        $app = $this->getApplication();
+        Config::setFacadeApplication($app);
+        $caller = new Caller(Config::class, ['is_safe' => true]);
+
+        $this->assertInstanceOf(Markup::class, $caller->get('twigbridge.twig.extension'));
     }
 }


### PR DESCRIPTION
Fixes:

```
TypeError : method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given
```