### PR TITLE
Fix view composing event

### DIFF
--- a/src/Node/EventNode.php
+++ b/src/Node/EventNode.php
@@ -5,6 +5,7 @@ namespace TwigBridge\Node;
 
 use Illuminate\Support\Str;
 use Illuminate\View\View;
+use Illuminate\View\ViewName;
 use Twig\Compiler;
 use Twig\Node\Node;
 
@@ -30,7 +31,7 @@ class EventNode extends Node
         }
         /** @var \Illuminate\View\Factory $factory */
         $env = resolve('view');
-        $viewName = $templateName;
+        $viewName = ViewName::normalize($templateName);
 
         $view = new View(
             $env,


### PR DESCRIPTION
This PR fixes view composing events. 

It seems that this edge-case broke with https://github.com/rcrowe/TwigBridge/pull/394

When listing like:
```
View::composer('layouts/partials/navigation', function ($view) {
    $view->with('categories', Category::ordered()->get());
});
```

This listens to `composing: layouts.partials.navigation` in Laravel. However, the current implementation triggers the event like: `composing: layouts/partials/navigation`. (slashes instead of dots).

When Twig 3.0 was merged, this was rewritten to maintain backwards compatibility with Twig 2, but the viewName isn't normalized in that event. Previously this was done in the custom `Template` class, but that was removed: https://github.com/rcrowe/TwigBridge/pull/394/files#diff-75946f0ecb9ab2b94b760306ef0b2d4bd4c768b4e2db5e764e0cfa8f09f9f4abL77

This PR adds the same normalization as before.

It can be seen as a breaking change, so perhaps good to release 0.14.0