### PR TITLE
Normalize event view names like Laravel

### DIFF
--- a/src/Node/EventNode.php
+++ b/src/Node/EventNode.php
@@ -5,6 +5,7 @@ namespace TwigBridge\Node;
 
 use Illuminate\Support\Str;
 use Illuminate\View\View;
+use Illuminate\View\ViewName;
 use Twig\Compiler;
 use Twig\Node\Node;
 
@@ -30,7 +31,7 @@ class EventNode extends Node
         }
         /** @var \Illuminate\View\Factory $factory */
         $env = resolve('view');
-        $viewName = $templateName;
+        $viewName = ViewName::normalize($templateName);
 
         $view = new View(
             $env,


### PR DESCRIPTION
`EventNode::triggerLaravelEvents()` triggers events with the given template name, not the normalized name. Laravel (in `ManagesEvents::addViewEvent()`) saves events with the normalized name.

In my project I use `/` delimiters everywhere, because it's much more readable than Laravel's `.`, and that works (in Laravel and in Twig) because names are normalized. Except in custom triggering events since the Twig 3 upgrade.

I feel like `EventNode` should do a

    $viewName = ViewName::normalize($templateName);

like `View\Factory::normalizeName()` does. But maybe I'm too me-focused right now. Laravel does the same for the first/main template render. I call it with `view('home/index')` in the controller, and Laravel (not TwigBridge) calls events for `home.index`. TwigBridge should do the same?

----

Something weird happens with the first/main template though. If I add a `composer('*')` listener, and print the `$view->name()` in the callback, I get the FULL path, AND the normalized path `home.index`. Only for the first/main template, not the includes and layouts called further in. Sounds a bit like #154 but not quite, and that's super old.

Some illustration (`dump($view->name)` in my `composer('*')`'s callback):

![p1111 icares homeblox nl_](https://user-images.githubusercontent.com/168024/157286295-ea0585bd-785b-4429-a824-712314cf9007.png)

- I call `view('home/index')` in my controller. Laravel triggers event for `home.index`
- Somehow (through TwigBridge, I can see that in the trace, but not really where/how) an event for the full path is triggered
- TwigBridge triggers the parent view's event (unnormalized `theme/page-default`)
- And then that view's parent view (unnormalized `theme/html`)

----

Also, why is there a `sprintf` in `EventNode::compile()`?