### PR TITLE
Fix deprecation messages for dynamic property creation with PHP 8.2+

### DIFF
--- a/src/Extension/Laravel/Dump.php
+++ b/src/Extension/Laravel/Dump.php
@@ -28,6 +28,11 @@ use Twig\Extension\AbstractExtension;
  */
 class Dump extends AbstractExtension
 {
+    /**
+     * @var \Symfony\Component\VarDumper\Cloner\VarCloner
+     */
+    protected $cloner;
+
     public function __construct()
     {
         $this->cloner = new VarCloner();

--- a/src/Extension/Loader/Loader.php
+++ b/src/Extension/Loader/Loader.php
@@ -24,6 +24,11 @@ use Twig\Extension\AbstractExtension;
 abstract class Loader extends AbstractExtension
 {
     /**
+     * @var \Illuminate\Config\Repository
+     */
+    protected $config;
+
+    /**
      * Create a new loader extension.
      *
      * @param \Illuminate\Config\Repository


### PR DESCRIPTION
In PHP 8.2, dynamic property creation was deprecated.

The constructors of 2 extensions were still creating a property (see #428)

This PR just created the properties, with the proper docblock.