### PR TITLE
Normalize path in compiler before sending it to twig->load()

### DIFF
--- a/src/Engine/Compiler.php
+++ b/src/Engine/Compiler.php
@@ -13,6 +13,7 @@ namespace TwigBridge\Engine;
 
 use Exception;
 use Illuminate\View\Compilers\CompilerInterface;
+use Illuminate\View\ViewName;
 use InvalidArgumentException;
 use Twig\Environment;
 use Twig\TemplateWrapper;
@@ -95,6 +96,12 @@ class Compiler implements CompilerInterface
     {
         // Load template
         try {
+            $path = str_replace(resource_path('views') . '/', '', $path);
+            if (str_ends_with($path, ".twig")) {
+                $path = substr($path, 0, -5);
+            }
+            $path = ViewName::normalize($path);
+
             $tmplWrapper = $this->twig->load($path);
         } catch (Exception $e) {
             throw new InvalidArgumentException("Error loading $path: ". $e->getMessage(), $e->getCode(), $e);


### PR DESCRIPTION
This PR addresses the issue https://github.com/rcrowe/TwigBridge/issues/438.

While compiling the twig templates, the view cache generated had the full path as the template name instead of the actual template name. This was a problem specially when using view composers. As we define view composers with template names, they were not being triggered due to the wrong name in cache files.

This fix adds code to normalize the path before sending it to twig->load() method, which expects the name of the template and not the path. Normalizing the path would convert it into the template name.

I'm not sure if this is the proper solution for this so please suggest alternatives if required.

Thanks!