### PR TITLE
Fix GetAttrNode deprecation warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "twig/twig": "~3.9",
+        "twig/twig": "~3.12",
         "illuminate/support": "^9|^10|^11",
         "illuminate/view": "^9|^10|^11"
     },

--- a/src/Node/GetAttrNode.php
+++ b/src/Node/GetAttrNode.php
@@ -31,10 +31,10 @@ class GetAttrNode extends GetAttrExpression
     /**
      * @inheritdoc
      */
-    public function __construct(array $nodes = [], array $attributes = [], int $lineno = 0, string $tag = null)
+    public function __construct(array $nodes = [], array $attributes = [], int $lineno = 0)
     {
         // Skip parent::__construct()
-        Node::__construct($nodes, $attributes, $lineno, $tag);
+        Node::__construct($nodes, $attributes, $lineno);
     }
 
     /**

--- a/src/NodeVisitor/GetAttrAdjuster.php
+++ b/src/NodeVisitor/GetAttrAdjuster.php
@@ -45,7 +45,7 @@ class GetAttrAdjuster implements NodeVisitorInterface
             'optimizable' => $node->getAttribute('optimizable'),
         ];
 
-        return new GetAttrNode($nodes, $attributes, $node->getTemplateLine(), $node->getNodeTag());
+        return new GetAttrNode($nodes, $attributes, $node->getTemplateLine());
     }
 
     /**


### PR DESCRIPTION
```
Since twig/twig 3.12: The "tag" constructor argument of the "TwigBridge\Node\GetAttrNode" class is deprecated and ignored (check which TokenParser class set it to "null"), the tag is now automatically set by the Parser when needed.
```

https://github.com/twigphp/Twig/blob/3.x/doc/deprecated.rst#nodes