### PR TITLE
Fixes Twig 3.15 new Node() deprecation in LaravelEventNodeVisitor

### DIFF
--- a/src/NodeVisitor/LaravelEventNodeVisitor.php
+++ b/src/NodeVisitor/LaravelEventNodeVisitor.php
@@ -29,7 +29,8 @@ class LaravelEventNodeVisitor implements NodeVisitorInterface
                 $isEmbedded = false;
             }
             if (!$isEmbedded) {
-                $node->setNode('display_start', new Node([new EventNode(), $node->getNode('display_start')]));
+                $displayStartNodes = $node->getNode('display_start');
+                $displayStartNodes->setNode(count($displayStartNodes), new EventNode());
             }
         }
         return $node;


### PR DESCRIPTION
Fixes Twig deprecation:

> Since twig/twig 3.15: Instantiating "Twig\Node\Node" directly is deprecated; the class will become abstract in 4.0.

I don't know starting from which Twig version my solution works. At least 3.15, but probably way earlier.