### PR TITLE
Work around deprecated "is_defined_test" attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "twig/twig": "~3.12",
+        "twig/twig": "~3.21",
         "illuminate/support": "^9|^10|^11|^12",
         "illuminate/view": "^9|^10|^11|^12"
     },

--- a/src/Node/GetAttrNode.php
+++ b/src/Node/GetAttrNode.php
@@ -47,7 +47,7 @@ class GetAttrNode extends GetAttrExpression
         // optimize array calls
         if ($this->getAttribute('optimizable')
             && (!$env->isStrictVariables() || $this->getAttribute('ignore_strict_check'))
-            && !$this->getAttribute('is_defined_test')
+            && !$this->isDefinedTestEnabled()
             && Template::ARRAY_CALL === $this->getAttribute('type')
         ) {
             $var = '$'.$compiler->getVarName();
@@ -91,7 +91,7 @@ class GetAttrNode extends GetAttrExpression
 
         $compiler->raw(', ')
             ->repr($this->getAttribute('type'))
-            ->raw(', ')->repr($this->getAttribute('is_defined_test'))
+            ->raw(', ')->repr($this->isDefinedTestEnabled())
             ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
             ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
             ->raw(', ')->repr($this->getNode('node')->getTemplateLine())

--- a/src/NodeVisitor/GetAttrAdjuster.php
+++ b/src/NodeVisitor/GetAttrAdjuster.php
@@ -40,12 +40,15 @@ class GetAttrAdjuster implements NodeVisitorInterface
 
         $attributes = [
             'type' => $node->getAttribute('type'),
-            'is_defined_test' => $node->getAttribute('is_defined_test'),
             'ignore_strict_check' => $node->getAttribute('ignore_strict_check'),
             'optimizable' => $node->getAttribute('optimizable'),
         ];
 
-        return new GetAttrNode($nodes, $attributes, $node->getTemplateLine());
+        $newNode = new GetAttrNode($nodes, $attributes, $node->getTemplateLine());
+
+        $node->isDefinedTestEnabled() && $newNode->enableDefinedTest();
+
+        return $newNode;
     }
 
     /**

--- a/tests/Node/GetAttrTest.php
+++ b/tests/Node/GetAttrTest.php
@@ -157,7 +157,6 @@ class GetAttrTest extends NodeTestCase
         $nodes = ['node' => $expr, 'attribute' => $attr, 'arguments' => $args];
         $attributes = [
             'type'                  => $type,
-            'is_defined_test'       => false,
             'ignore_strict_check'   => false,
             'optimizable'           => true
         ];


### PR DESCRIPTION
Fixes #459.

Minimum Twig version adjusted and now is 3.21.